### PR TITLE
fix: 支持通过url配置es地址，移除无用配置项

### DIFF
--- a/easy-es-boot-starter/src/main/java/org/dromara/easyes/starter/config/EasyEsConfigProperties.java
+++ b/easy-es-boot-starter/src/main/java/org/dromara/easyes/starter/config/EasyEsConfigProperties.java
@@ -30,10 +30,6 @@ public class EasyEsConfigProperties {
      */
     private String address = "127.0.0.1:9200";
     /**
-     * schema 模式
-     */
-    private String schema = "http";
-    /**
      * username of es 用户名,可缺省
      */
     private String username;

--- a/easy-es-boot-starter/src/main/java/org/dromara/easyes/starter/config/EsAutoConfiguration.java
+++ b/easy-es-boot-starter/src/main/java/org/dromara/easyes/starter/config/EsAutoConfiguration.java
@@ -53,15 +53,9 @@ public class EsAutoConfiguration {
         if (StringUtils.isEmpty(address)) {
             throw ExceptionUtils.eee("please config the es address");
         }
-        if (!address.contains(COLON)) {
-            throw ExceptionUtils.eee("the address must contains port and separate by ':'");
-        }
-        String schema = StringUtils.isEmpty(easyEsConfigProperties.getSchema())
-                ? DEFAULT_SCHEMA : easyEsConfigProperties.getSchema();
         List<HttpHost> hostList = new ArrayList<>();
         Arrays.stream(easyEsConfigProperties.getAddress().split(","))
-                .forEach(item -> hostList.add(new HttpHost(item.split(":")[0],
-                        Integer.parseInt(item.split(":")[1]), schema)));
+                .forEach(item -> hostList.add(HttpHost.create(item)));
 
         // 转换成 HttpHost 数组
         HttpHost[] httpHost = hostList.toArray(new HttpHost[]{});


### PR DESCRIPTION

1、修改easy-es-boot-starter/src/main/java/org/dromara/easyes/starter/config/EsAutoConfiguration.java类，使其支持使用URL地址配置es；
2、修改easy-es-boot-starter/src/main/java/org/dromara/easyes/starter/config/EasyEsConfigProperties.java类，移除其无用配置项schema。