### PR TITLE
修复 Spring Boot Actuator 兼容性问题

### DIFF
--- a/easy-es-actuator/pom.xml
+++ b/easy-es-actuator/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.dromara.easy-es</groupId>
+        <artifactId>easy-es-parent</artifactId>
+        <version>3.0.0</version>
+        <relativePath>../easy-es-parent</relativePath>
+    </parent>
+
+    <artifactId>easy-es-actuator</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.dromara.easy-es</groupId>
+            <artifactId>easy-es-core</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/easy-es-actuator/src/main/java/org/dromara/easyes/starter/health/EasyElasticsearchHealthAutoConfiguration.java
+++ b/easy-es-actuator/src/main/java/org/dromara/easyes/starter/health/EasyElasticsearchHealthAutoConfiguration.java
@@ -1,0 +1,25 @@
+package org.dromara.easyes.starter.health;
+
+import org.dromara.easyes.starter.health.indicator.ElasticsearchRestHealthIndicator;
+import org.dromara.easyes.starter.health.properties.EasyElasticsearchHealthProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan("org.dromara.easyes.starter.health")
+@EnableConfigurationProperties(EasyElasticsearchHealthProperties.class)
+public class EasyElasticsearchHealthAutoConfiguration {
+
+    /**
+     * 心跳检查自动装配
+     * @return 心跳检查自动装配
+     */
+    @Bean("elasticsearchHealthIndicator")
+    @ConditionalOnProperty(value = "easy-es.health.elasticsearch.enabled",havingValue = "true",matchIfMissing = true)
+    public ElasticsearchRestHealthIndicator elasticsearchHealthIndicator() {
+        return new ElasticsearchRestHealthIndicator();
+    }
+}

--- a/easy-es-actuator/src/main/java/org/dromara/easyes/starter/health/indicator/ElasticsearchRestHealthIndicator.java
+++ b/easy-es-actuator/src/main/java/org/dromara/easyes/starter/health/indicator/ElasticsearchRestHealthIndicator.java
@@ -1,0 +1,84 @@
+package org.dromara.easyes.starter.health.indicator;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.HealthStatus;
+import co.elastic.clients.elasticsearch.cluster.ElasticsearchClusterClient;
+import co.elastic.clients.elasticsearch.cluster.HealthResponse;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.apache.http.HttpHost;
+import org.dromara.easyes.core.cache.BaseCache;
+import org.dromara.easyes.core.kernel.BaseEsMapper;
+import org.dromara.easyes.core.kernel.BaseEsMapperImpl;
+import org.elasticsearch.client.Node;
+import org.elasticsearch.client.RestClient;
+import org.springframework.beans.BeansException;
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.util.CollectionUtils;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Elasticsearch健康检查指示器
+ * <p>
+ */
+public class ElasticsearchRestHealthIndicator extends AbstractHealthIndicator implements ApplicationContextAware {
+
+    private ApplicationContext applicationContext;
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    protected void doHealthCheck(Health.Builder builder) throws Exception {
+        Map<String, Object> details = new HashMap<>();
+        Map<String, BaseEsMapper> beansOfType = applicationContext.getBeansOfType(BaseEsMapper.class);
+        if (CollectionUtils.isEmpty(beansOfType)) {
+            builder.up();
+            return;
+        }
+        Collection<BaseEsMapperImpl<?>> allImpl = BaseCache.getAllImpl();
+        if (CollectionUtils.isEmpty(allImpl)) {
+            builder.up();
+            return;
+        }
+        Collection<ElasticsearchClient> elasticsearchClients = allImpl
+                .stream()
+                .map(BaseEsMapperImpl::getClient)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        for (ElasticsearchClient elasticsearchClient : elasticsearchClients) {
+            ElasticsearchClusterClient cluster = elasticsearchClient.cluster();
+            HealthResponse health = cluster.health();
+            HealthStatus status = health.status();
+            if (status.equals(HealthStatus.Red)) {
+                ElasticsearchTransport transport =  cluster._transport();
+                if (transport instanceof RestClientTransport ) {
+                    RestClientTransport restTransport = (RestClientTransport)transport;
+                    RestClient restClient = restTransport.restClient();
+                    List<Node> nodes = restClient.getNodes();
+                    String clusterName = health.clusterName();
+                    List<String> message = new ArrayList<>();
+
+                    for (Node node : nodes) {
+                        HttpHost host = node.getHost();
+                        message.add("node:" + host.getHostName() + ":" + host.getPort());
+                    }
+                    details.put(clusterName,message);
+                }
+            }
+        }
+        if (CollectionUtils.isEmpty(details)) {
+            builder.up();
+            return;
+        }
+        builder.withDetails(details);
+        builder.outOfService();
+    }
+}

--- a/easy-es-actuator/src/main/java/org/dromara/easyes/starter/health/properties/EasyElasticsearchHealthProperties.java
+++ b/easy-es-actuator/src/main/java/org/dromara/easyes/starter/health/properties/EasyElasticsearchHealthProperties.java
@@ -1,0 +1,21 @@
+package org.dromara.easyes.starter.health.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "easy-es.health.elasticsearch")
+public class EasyElasticsearchHealthProperties {
+    /**
+     * 心跳检查是否开启，默认：开启
+     */
+    private boolean enabled = true;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/easy-es-actuator/src/main/resources/META-INF/spring.factories
+++ b/easy-es-actuator/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.dromara.easyes.starter.health.EasyElasticsearchHealthAutoConfiguration

--- a/easy-es-actuator/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/easy-es-actuator/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.dromara.easyes.starter.health.EasyElasticsearchHealthAutoConfiguration

--- a/easy-es-core/src/main/java/org/dromara/easyes/core/cache/BaseCache.java
+++ b/easy-es-core/src/main/java/org/dromara/easyes/core/cache/BaseCache.java
@@ -176,4 +176,12 @@ public class BaseCache {
         String idFieldName = EntityInfoHelper.getEntityInfo(entityClass).getKeyProperty();
         return getterInvoke(entityClass, idFieldName, obj);
     }
+
+    /**
+     * 获取所有BaseEsMapperImpl实例
+     * @return 实例集合
+     */
+    public static Collection<BaseEsMapperImpl<?>> getAllImpl() {
+        return baseEsMapperInstanceMap.values();
+    }
 }

--- a/easy-es-core/src/main/java/org/dromara/easyes/core/kernel/BaseEsMapperImpl.java
+++ b/easy-es-core/src/main/java/org/dromara/easyes/core/kernel/BaseEsMapperImpl.java
@@ -715,6 +715,14 @@ public class BaseEsMapperImpl<T> implements BaseEsMapper<T> {
     }
 
     /**
+     * 获取客户端
+     * @return es 客户端
+     */
+    public ElasticsearchClient getClient() {
+        return client;
+    }
+
+    /**
      * 执行批量插入数据
      *
      * @param entityList 数据列表

--- a/easy-es-parent/pom.xml
+++ b/easy-es-parent/pom.xml
@@ -27,6 +27,7 @@
         <module>../easy-es-common</module>
         <module>../easy-es-solon-plugin</module>
         <module>../easy-es-spring</module>
+        <module>../easy-es-actuator</module>
     </modules>
 
     <properties>
@@ -136,6 +137,11 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-aop</artifactId>
                 <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+                <version>${spring-boot.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <module>easy-es-spring-test</module>
         <module>easy-es-springboot-sample</module>
         <module>easy-es-springboot-test</module>
-
+        <module>easy-es-actuator</module>
     </modules>
 
     <properties>
@@ -79,6 +79,11 @@
                 <groupId>org.noear</groupId>
                 <artifactId>solon-logging-logback</artifactId>
                 <version>${solon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+                <version>${spring-boot.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
# 背景说明：
在使用 Spring Boot 2.x + Spring Boot Actuator 时，与Actuator 自带的 Elasticsearch 健康检查对客户端集成存在问题。Actuator 默认依赖 Spring Boot 内置 Elasticsearch 客户端配置，当项目使用 自定义  easy-es 的 Elasticsearch Client  时，Actuator 无法正确获取实际的 Elasticsearch 连接信息，健康检查默认指向 localhost，导致 Spring Boot Admin 健康状态不准确。

# 本次改动目的：
本合并请求引入一个 Elasticsearch Health Adapter，用于：
- 适配自定义 Elasticsearch 客户端
- 将真实的 Elasticsearch 集群健康信息上报给 Spring Boot Actuator
- 使 Spring Boot Admin 能正确展示 Elasticsearch 集群状态


#自动装配支持
- 提供 Spring Boot 自动装配（AutoConfiguration）
- 支持通过配置开关启用或关闭健康检查
```yml
easy-es:
  health:
    elasticsearch:
      enabled: true
 ```